### PR TITLE
Clarify which IB API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### IBKR API Client
 
-This is just another Python client for the Interactive Brokers API, which is using the OAuth1.0a protocol for authentication.
-Main benefits of this client are:
+This is just another Python client for the [Interactive Brokers Client Portal REST API](https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#introduction),
+which is using the OAuth1.0a protocol for authentication. Main benefits of this client are:
  - You don't need to install Client Portal Gateway
  - Automatic authentication with live session token renewal
 


### PR DESCRIPTION
There are [at least 3 IB APIs](https://www.interactivebrokers.com/campus/ibkr-api-page/getting-started/#webapi):

- the old TWS API, stream-oriented (not REST)

- Client Portal REST API, with redundant endpoints and inconsistent and confusing types, e.g. [Contract information by Contract ID](https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#info-conid-contract) vs.  [Search SecDef information by conid](https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#secdef-info-contract) vs. [Search the security definition by Contract ID](https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#trsrv-conid-contract) **[and more](https://github.com/Voyz/ibeam/issues/229)**

- "Web API", with some very different endpoints, e.g. [/trsrv/stocks](https://www.interactivebrokers.com/campus/ibkr-api-page/web-api-trading/#equities-14), different field names, and no parameters or response objects formally defined (the docs read like a tutorial/learn by example).
